### PR TITLE
strict comparison

### DIFF
--- a/palindromeCheck.js
+++ b/palindromeCheck.js
@@ -15,7 +15,7 @@ function palindromeCheck(event) {
 	var strReverse = word.split('').reverse().join('');
 	
 	//test the reverse to the original string
-	if (strReverse == word)
+	if (strReverse === word)
 	{
 		output.innerHTML = "True- " + word + " is a palindrome";
 	}


### PR DESCRIPTION
Since there is no reason to use `==`, use of `===` is suggested.
